### PR TITLE
Added VAP controls to stop users getting root

### DIFF
--- a/clusters/dawntest/kustomization.yaml
+++ b/clusters/dawntest/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - configmap.yaml
   - credentials-sealed.yaml
   - ../../components/intel-device-plugin
+  - ../../components/security
 
 # Patch the Helm release for the cluster to update the release name
 #   This ensures we get nicely named resources in OpenStack

--- a/components/security/helmchart.yaml
+++ b/components/security/helmchart.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
 spec:
   chart: restricted-pss-vaps
-  version: 0.1.0
+  version: 0.2.0
   sourceRef:
     kind: HelmRepository
     name: restricted-pss-vaps

--- a/components/security/helmchart.yaml
+++ b/components/security/helmchart.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmChart
+metadata:
+  name: restricted-pss-vaps
+  namespace: default
+spec:
+  chart: restricted-pss-vaps
+  version: 0.1.0
+  sourceRef:
+    kind: HelmRepository
+    name: restricted-pss-vaps
+  interval: 1h

--- a/components/security/helmchart.yaml
+++ b/components/security/helmchart.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
 spec:
   chart: restricted-pss-vaps
-  version: 0.2.0
+  version: 0.3.0
   sourceRef:
     kind: HelmRepository
     name: restricted-pss-vaps

--- a/components/security/helmrelease.yaml
+++ b/components/security/helmrelease.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: restricted-pss-vaps
+  namespace: default
+spec:
+  chartRef:
+    kind: HelmChart
+    name: restricted-pss-vaps
+  releaseName: restricted-pss-vaps
+  valuesFrom:
+  - kind: ConfigMap
+    name: restricted-pss-vaps-values
+    valuesKey: values.yaml
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+  driftDetection:
+    mode: enabled
+  interval: 5m

--- a/components/security/helmrepository.yaml
+++ b/components/security/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: restricted-pss-vaps
+  namespace: default
+spec:
+  url: https://stackhpc.github.io/restricted-pss-vaps-helm
+  interval: 1h

--- a/components/security/kustomization.yaml
+++ b/components/security/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+  - helmrepository.yaml
+  - helmchart.yaml
+  - helmrelease.yaml
+
+configurations:
+  - kustomizeconfig.yaml
+
+configMapGenerator:
+- name: restricted-pss-vaps-values
+  namespace: default
+  files:
+    - values.yaml=values.yaml

--- a/components/security/kustomizeconfig.yaml
+++ b/components/security/kustomizeconfig.yaml
@@ -1,0 +1,6 @@
+nameReference:
+- kind: ConfigMap
+  version: v1
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease

--- a/components/security/values.yaml
+++ b/components/security/values.yaml
@@ -1,0 +1,26 @@
+defaultBindingNamespaceSelector:
+  matchExpressions:
+  - key: kubernetes.io/metadata.name
+    operator: NotIn
+    values:
+    - capi-addon-system
+    - capi-janitor-system
+    - capi-kubeadm-bootstrap-system
+    - capi-kubeadm-control-plane-system
+    - capi-operator-system
+    - capi-self
+    - capi-system
+    - capo-system
+    - cert-manager
+    - flux-system
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - node-problem-detector
+    - openstack-system
+    - sealed-secrets-system
+    - intel
+
+allowedCapabilities:
+- NET_BIND_SERVICE
+- IPC_LOCK

--- a/components/security/values.yaml
+++ b/components/security/values.yaml
@@ -20,6 +20,7 @@ defaultBindingNamespaceSelector:
     - openstack-system
     - sealed-secrets-system
     - intel
+    - falco
 
 allowedCapabilities:
 - NET_BIND_SERVICE


### PR DESCRIPTION
Deploys https://github.com/stackhpc/restricted-pss-vaps-helm into cluster, which currently has controls to enforce 
- Host namespaces
- Privileged containers
- Capabilities (at restricted level but configured via helm values here to allow IPC_LOCK)
- Hostpath volumes
- Host ports
- Apparmor
- Privilege escalation
- Running as non-root
- Running as non-root user

but eventually needs rest of https://kubernetes.io/docs/concepts/security/pod-security-standards/